### PR TITLE
Patch wallpaper plugin support for older homescreen skill

### DIFF
--- a/.github/workflows/skill_tests.yml
+++ b/.github/workflows/skill_tests.yml
@@ -11,7 +11,7 @@ jobs:
   skill_unit_tests:
     uses: neongeckocom/.github/.github/workflows/skill_tests.yml@master
   skill_intent_tests:
-    uses: neongeckocom/.github/.github/workflows/skill_test_intents.yml@FEAT_UpdateIntentTestPythonVersions
+    uses: neongeckocom/.github/.github/workflows/skill_test_intents.yml@master
     with:
       ovos_versions: "[]"
   skill_resource_tests:

--- a/.github/workflows/skill_tests.yml
+++ b/.github/workflows/skill_tests.yml
@@ -11,7 +11,9 @@ jobs:
   skill_unit_tests:
     uses: neongeckocom/.github/.github/workflows/skill_tests.yml@master
   skill_intent_tests:
-    uses: neongeckocom/.github/.github/workflows/skill_test_intents.yml@master
+    uses: neongeckocom/.github/.github/workflows/skill_test_intents.yml@FEAT_UpdateIntentTestPythonVersions
+    with:
+      ovos_versions: "[]"
   skill_resource_tests:
     uses: neongeckocom/.github/.github/workflows/skill_test_resources.yml@master
   skill_install_tests:

--- a/__init__.py
+++ b/__init__.py
@@ -58,7 +58,14 @@ class CoreReadySkill(OVOSSkill):
         """
         return self.settings.get("speak_ready") is not False
 
-    def handle_ready(self, _: Message):
+    @property
+    def patch_homescreen_support(self):
+        """
+        Emit homescreen update event for wallpaper plugin backwards-compat.
+        """
+        return self.settings.get("patch_homescreen_support")
+
+    def handle_ready(self, message: Message):
         """
         Handle `mycroft.ready` event. Notify the user everything is ready if
         configured.
@@ -67,6 +74,13 @@ class CoreReadySkill(OVOSSkill):
             self.speak_dialog("ready")
         else:
             LOG.info("Ready notification disabled in settings")
+
+        if self.patch_homescreen_support:
+            # TODO: This is patching compat with the wallpaper plugin and the
+            #   homescreen skill. Functionality was added in
+            #   `skill-ovos-homescreen` 2.0, but it requires an incompatible
+            #   version of `ovos-workshop`
+            self.bus.emit(message.forward("homescreen.metadata.get"))
 
     @intent_handler("enable_ready_notification.intent")
     def handle_enable_notification(self, _: Message):


### PR DESCRIPTION
# Description
Implement patch to emit `homescreen.metadata.get` so Mark2 wallpaper is displayed on boot

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
https://github.com/OpenVoiceOS/ovos-skill-homescreen/pull/130 Added this functionality to `skill-ovos-homescreen` but also introduced a new `ovos-workshop` dependency that is not compatible with other Neon skills/dependencies